### PR TITLE
Made cygwin an unsupported OS

### DIFF
--- a/make-config.sh
+++ b/make-config.sh
@@ -328,7 +328,7 @@ case `uname` in
     SunOS)
         sbcl_os="sunos"
         ;;
-    CYGWIN* | WindowsNT | MINGW* | MSYS*)
+    WindowsNT | MINGW* | MSYS*)
         sbcl_os="win32"
         ;;
     Haiku)


### PR DESCRIPTION
Cygwin is no longer supported by sbscl according to this ticket: https://bugs.launchpad.net/sbcl/+bug/1720642

Changed make-config so it will fail when the build starts.